### PR TITLE
Fix bash script for mac and for variables

### DIFF
--- a/tutorial/mk_param_var.sh
+++ b/tutorial/mk_param_var.sh
@@ -6,14 +6,14 @@ awk '!seen[$0]++' | \
 sed -e 's/[[:space:]]\+//g' | \
 sed -e "s/\(.*\)/'\1'/" | \
 sed 's/$/,/' |
-sed -e 's/^/	/g' > param_var_mid
+sed -e 's/^/	/g' |
+sed -e 's/    //g' > param_var_mid
 
 echo 'param_names = [\' > first_line
 
 echo "	##
 	'len_f_params'\
 ]
-
 for idx,name in enumerate(param_names):
     exec('%s=%d'%(name,idx))" > last_line
 
@@ -34,14 +34,14 @@ awk '!seen[$0]++' | \
 sed -e 's/[[:space:]]\+//g' | \
 sed -e "s/\(.*\)/'\1'/" | \
 sed 's/$/,/' |
-sed -e 's/^/	/g' > var_var_mid
+sed -e 's/^/	/g' |
+sed -e 's/    //g' > var_var_mid
 
 echo 'param_names = [\' > first_line
 
 echo "	##
 	'len_f_params'\
 ]
-
 for idx,name in enumerate(param_names):
     exec('%s=%d'%(name,idx))" > last_line
 

--- a/tutorial/mk_param_var.sh
+++ b/tutorial/mk_param_var.sh
@@ -6,12 +6,12 @@ awk '!seen[$0]++' | \
 sed -e 's/[[:space:]]\+//g' | \
 sed -e "s/\(.*\)/'\1'/" | \
 sed 's/$/,/' |
-sed -e $'s/^/\t/g' > param_var_mid
+sed -e 's/^/	/g' > param_var_mid
 
 echo 'param_names = [\' > first_line
 
-echo "    ##
-    'len_f_params'\
+echo "	##
+	'len_f_params'\
 ]
 
 for idx,name in enumerate(param_names):
@@ -27,19 +27,19 @@ rm last_line
 echo "done processing parameters"
 
 # script to extract variables from variables constant
-grep '\[V' ../biomass/model/differential_equation.py | \
+grep 'dydt\[V' ../biomass/model/differential_equation.py | \
 sed 's/dydt\[V\.//g' | \
 sed 's/\].*//g' | \
 awk '!seen[$0]++' | \
 sed -e 's/[[:space:]]\+//g' | \
 sed -e "s/\(.*\)/'\1'/" | \
 sed 's/$/,/' |
-sed -e $'s/^/\t/g' > var_var_mid
+sed -e 's/^/	/g' > var_var_mid
 
 echo 'param_names = [\' > first_line
 
-echo "    ##
-    'len_f_params'\
+echo "	##
+	'len_f_params'\
 ]
 
 for idx,name in enumerate(param_names):


### PR DESCRIPTION
Fix bash script for mac: no more white spaces after opening square brackets
Also fixed for variables